### PR TITLE
Fix glUniformMatrix4x3fv typo.

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -2893,7 +2893,7 @@ var LibraryGL = {
     GLctx.uniformMatrix3x4fv(location, transpose, view);
   },
 
-  glUniformMatrix3x4fv__sig: 'viiii',
+  glUniformMatrix4x3fv__sig: 'viiii',
   glUniformMatrix4x3fv: function(location, count, transpose, value) {
 #if GL_ASSERTIONS
     GL.validateGLObjectID(GL.uniforms, location, 'glUniformMatrix4x3fv', 'location');


### PR DESCRIPTION
There is a obvious typo on glUniformMatrix4x3fv_sig. This pull request fixes the typo. 